### PR TITLE
Adds Carthage/Build into .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ DerivedData
 *.xcuserstate
 .DS_Store
 Carthage/Checkouts
+Carthage/Build


### PR DESCRIPTION
Whilst making this change, I noticed `Carthage/Checkouts` is in .gitignore in keychain-swift – not sure that should be the case actually?