### PR TITLE
Migrate to Swift 2.3

### DIFF
--- a/KeychainSwift.xcodeproj/project.pbxproj
+++ b/KeychainSwift.xcodeproj/project.pbxproj
@@ -444,9 +444,11 @@
 					};
 					7ED6C96B1B1C118F00FE8090 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 					7ED6C9761B1C118F00FE8090 = {
 						CreatedOnToolsVersion = 6.4;
+						LastSwiftMigration = 0800;
 					};
 					7ED6C99C1B1C133500FE8090 = {
 						CreatedOnToolsVersion = 6.4;
@@ -876,6 +878,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.marketplacer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -893,6 +896,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.marketplacer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -911,6 +915,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "KeychainSwiftTests/KeychainSwiftTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -924,6 +929,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.marketplacer.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "KeychainSwiftTests/KeychainSwiftTests-Bridging-Header.h";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};

--- a/KeychainSwift.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
+++ b/KeychainSwift.xcodeproj/xcshareddata/xcschemes/Demo.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "7ED6C99C1B1C133500FE8090"
-               BuildableName = "Demo.app"
+               BuildableName = "Keychain Swift.app"
                BlueprintName = "Demo"
                ReferencedContainer = "container:KeychainSwift.xcodeproj">
             </BuildableReference>
@@ -57,7 +57,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7ED6C99C1B1C133500FE8090"
-            BuildableName = "Demo.app"
+            BuildableName = "Keychain Swift.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:KeychainSwift.xcodeproj">
          </BuildableReference>
@@ -80,7 +80,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7ED6C99C1B1C133500FE8090"
-            BuildableName = "Demo.app"
+            BuildableName = "Keychain Swift.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:KeychainSwift.xcodeproj">
          </BuildableReference>
@@ -99,7 +99,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7ED6C99C1B1C133500FE8090"
-            BuildableName = "Demo.app"
+            BuildableName = "Keychain Swift.app"
             BlueprintName = "Demo"
             ReferencedContainer = "container:KeychainSwift.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
This PR is just to show how easy it would be for this library to support Swift 2.3 in Xcode 8. There are no source changes, only a couple additional build settings. Do not merge this PR; instead, to accept it, please branch off the 3.0.16 tag and cherry-pick this change.

Fixes #30.

/cc @friedbunny