### PR TITLE
Compatibility with Xcode 8 Beta 6

### DIFF
--- a/Distrib/KeychainSwiftDistrib.swift
+++ b/Distrib/KeychainSwiftDistrib.swift
@@ -23,7 +23,7 @@ A collection of helper functions for saving text and data in the keychain.
 */
 public class KeychainSwift {
   
-  var lastQueryParameters: [String: NSObject]? // Used by the unit tests
+  var lastQueryParameters: [String: Any]? // Used by the unit tests
   
   /// Contains result code from the last operation. Value is noErr (0) for a successful result.
   public var lastResultCode: OSStatus = noErr
@@ -103,7 +103,7 @@ public class KeychainSwift {
       
     let prefixedKey = keyWithPrefix(key)
       
-    var query: [String : NSObject] = [
+    var query: [String : Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
       KeychainSwiftConstants.valueData   : value,
@@ -172,7 +172,7 @@ public class KeychainSwift {
   public func getData(_ key: String) -> Data? {
     let prefixedKey = keyWithPrefix(key)
     
-    var query: [String: NSObject] = [
+    var query: [String: Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
       KeychainSwiftConstants.returnData  : kCFBooleanTrue,
@@ -185,8 +185,8 @@ public class KeychainSwift {
     
     var result: AnyObject?
     
-    lastResultCode = withUnsafeMutablePointer(&result) {
-      SecItemCopyMatching(query, UnsafeMutablePointer($0))
+    lastResultCode = withUnsafeMutablePointer(to: &result) {
+      SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
     }
     
     if lastResultCode == noErr { return result as? Data }
@@ -220,7 +220,7 @@ public class KeychainSwift {
   public func delete(_ key: String) -> Bool {
     let prefixedKey = keyWithPrefix(key)
 
-    var query: [String: NSObject] = [
+    var query: [String: Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey
     ]
@@ -243,7 +243,7 @@ public class KeychainSwift {
   */
   @discardableResult
   public func clear() -> Bool {
-    var query: [String: NSObject] = [ kSecClass as String : kSecClassGenericPassword ]
+    var query: [String: Any] = [ kSecClass as String : kSecClassGenericPassword ]
     query = addAccessGroupWhenPresent(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
     lastQueryParameters = query
@@ -258,10 +258,10 @@ public class KeychainSwift {
     return "\(keyPrefix)\(key)"
   }
   
-  func addAccessGroupWhenPresent(_ items: [String: NSObject]) -> [String: NSObject] {
+  func addAccessGroupWhenPresent(_ items: [String: Any]) -> [String: Any] {
     guard let accessGroup = accessGroup else { return items }
     
-    var result: [String: NSObject] = items
+    var result: [String: Any] = items
     result[KeychainSwiftConstants.accessGroup] = accessGroup
     return result
   }
@@ -276,9 +276,9 @@ public class KeychainSwift {
    - returns: the dictionary with kSecAttrSynchronizable item added if it was requested. Otherwise, it returns the original dictionary.
  
   */
-  func addSynchronizableIfRequired(_ items: [String: NSObject], addingItems: Bool) -> [String: NSObject] {
+  func addSynchronizableIfRequired(_ items: [String: Any], addingItems: Bool) -> [String: Any] {
     if !synchronizable { return items }
-    var result: [String: NSObject] = items
+    var result: [String: Any] = items
     result[KeychainSwiftConstants.attrSynchronizable] = addingItems == true ? true : kSecAttrSynchronizableAny
     return result
   }

--- a/KeychainSwift/KeychainSwift.swift
+++ b/KeychainSwift/KeychainSwift.swift
@@ -8,7 +8,7 @@ A collection of helper functions for saving text and data in the keychain.
 */
 public class KeychainSwift {
   
-  var lastQueryParameters: [String: NSObject]? // Used by the unit tests
+  var lastQueryParameters: [String: Any]? // Used by the unit tests
   
   /// Contains result code from the last operation. Value is noErr (0) for a successful result.
   public var lastResultCode: OSStatus = noErr
@@ -88,7 +88,7 @@ public class KeychainSwift {
       
     let prefixedKey = keyWithPrefix(key)
       
-    var query: [String : NSObject] = [
+    var query: [String : Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
       KeychainSwiftConstants.valueData   : value,
@@ -157,7 +157,7 @@ public class KeychainSwift {
   public func getData(_ key: String) -> Data? {
     let prefixedKey = keyWithPrefix(key)
     
-    var query: [String: NSObject] = [
+    var query: [String: Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey,
       KeychainSwiftConstants.returnData  : kCFBooleanTrue,
@@ -170,8 +170,8 @@ public class KeychainSwift {
     
     var result: AnyObject?
     
-    lastResultCode = withUnsafeMutablePointer(&result) {
-      SecItemCopyMatching(query, UnsafeMutablePointer($0))
+    lastResultCode = withUnsafeMutablePointer(to: &result) {
+      SecItemCopyMatching(query as CFDictionary, UnsafeMutablePointer($0))
     }
     
     if lastResultCode == noErr { return result as? Data }
@@ -205,7 +205,7 @@ public class KeychainSwift {
   public func delete(_ key: String) -> Bool {
     let prefixedKey = keyWithPrefix(key)
 
-    var query: [String: NSObject] = [
+    var query: [String: Any] = [
       KeychainSwiftConstants.klass       : kSecClassGenericPassword,
       KeychainSwiftConstants.attrAccount : prefixedKey
     ]
@@ -228,7 +228,7 @@ public class KeychainSwift {
   */
   @discardableResult
   public func clear() -> Bool {
-    var query: [String: NSObject] = [ kSecClass as String : kSecClassGenericPassword ]
+    var query: [String: Any] = [ kSecClass as String : kSecClassGenericPassword ]
     query = addAccessGroupWhenPresent(query)
     query = addSynchronizableIfRequired(query, addingItems: false)
     lastQueryParameters = query
@@ -243,10 +243,10 @@ public class KeychainSwift {
     return "\(keyPrefix)\(key)"
   }
   
-  func addAccessGroupWhenPresent(_ items: [String: NSObject]) -> [String: NSObject] {
+  func addAccessGroupWhenPresent(_ items: [String: Any]) -> [String: Any] {
     guard let accessGroup = accessGroup else { return items }
     
-    var result: [String: NSObject] = items
+    var result: [String: Any] = items
     result[KeychainSwiftConstants.accessGroup] = accessGroup
     return result
   }
@@ -261,9 +261,9 @@ public class KeychainSwift {
    - returns: the dictionary with kSecAttrSynchronizable item added if it was requested. Otherwise, it returns the original dictionary.
  
   */
-  func addSynchronizableIfRequired(_ items: [String: NSObject], addingItems: Bool) -> [String: NSObject] {
+  func addSynchronizableIfRequired(_ items: [String: Any], addingItems: Bool) -> [String: Any] {
     if !synchronizable { return items }
-    var result: [String: NSObject] = items
+    var result: [String: Any] = items
     result[KeychainSwiftConstants.attrSynchronizable] = addingItems == true ? true : kSecAttrSynchronizableAny
     return result
   }

--- a/KeychainSwiftTests/AccessGroupTests.swift
+++ b/KeychainSwiftTests/AccessGroupTests.swift
@@ -16,7 +16,7 @@ class AccessGroupTests: XCTestCase {
   // MARK: - Add access group
   
   func testAddAccessGroup() {
-    let items: [String: NSObject] = [
+    let items: [String: Any] = [
       "one": "two"
     ]
     
@@ -29,7 +29,7 @@ class AccessGroupTests: XCTestCase {
   }
   
   func testAddAccessGroup_nil() {
-    let items: [String: NSObject] = [
+    let items: [String: Any] = [
       "one": "two"
     ]
     

--- a/KeychainSwiftTests/SynchronizableTests.swift
+++ b/KeychainSwiftTests/SynchronizableTests.swift
@@ -16,7 +16,7 @@ class SynchronizableTests: XCTestCase {
   // MARK: - addSynchronizableIfRequired
   
   func testAddSynchronizableGroup_addItemsFalse() {
-    let items: [String: NSObject] = [
+    let items: [String: Any] = [
       "one": "two"
     ]
     
@@ -29,7 +29,7 @@ class SynchronizableTests: XCTestCase {
   }
   
   func testAddSynchronizableGroup_addItemsTrue() {
-    let items: [String: NSObject] = [
+    let items: [String: Any] = [
       "one": "two"
     ]
     
@@ -42,7 +42,7 @@ class SynchronizableTests: XCTestCase {
   }
   
   func testAddSynchronizableGroup_nil() {
-    let items: [String: NSObject] = [
+    let items: [String: Any] = [
       "one": "two"
     ]
     

--- a/macOS Demo/ViewController.swift
+++ b/macOS Demo/ViewController.swift
@@ -29,12 +29,12 @@ class ViewController: NSViewController {
     updateValueLabel()
     errorLabel.stringValue = ""
   }
-
-  override var representedObject: AnyObject? {
-    didSet {
-    // Update the view, if already loaded.
-    }
-  }
+	
+//  override var representedObject: Any? {
+//    didSet {
+//    // Update the view, if already loaded.
+//    }
+//  }
 
   @IBAction func onSaveTapped(_ sender: AnyObject) {
     keychain.synchronizable = synchronizableButton.state == NSOnState


### PR DESCRIPTION
I think most of the issues where caused by the [27639935 update](http://adcdownload.apple.com/Developer_Tools/Xcode_8_beta_6/Release_Notes_for_Xcode_8_beta_6.pdf):

> • Since ‘id’ now imports as ‘Any’ rather than ‘AnyObject’, you may see errors where you were previously performing dynamic lookup on ‘AnyObject’. For example in:
```
> guard let fileEnumerator = FileManager.default.enumerator(atPath: path)
> else {
>  return
> }
> for fileName in fileEnumerator {
>  if fileName.hasSuffix(".txt") {
>  // error: value of type ‘Element’ (aka ‘Any’) has no member
> hasSuffix
>  print(fileName)
>  }
> }
```
> The fix is to either cast to AnyObject explicitly before doing the dynamic lookup, or force cast to a specific object type:
```
> guard let fileEnumerator = FileManager.default.enumerator(atPath: path)
> else {
>  return
> }
> for fileName in fileEnumerator {
>  if (fileName as AnyObject).hasSuffix(".txt") {
>  // cast to AnyObject
>  print(fileName)
>  }
> }
```
> (27639935)

Can you check if everything is working for you @evgenyneu please?
I basically replaced all `[String: NSObject]` declarations by `[String: Any]`.

Closes #32.