### PR TITLE
Fix add Swift version to podspec file

### DIFF
--- a/KeychainSwift.podspec
+++ b/KeychainSwift.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.10"
   s.watchos.deployment_target = "2.0"
   s.tvos.deployment_target = "9.0"
+  s.xcconfig    = { 'SWIFT_VERSION' => '3.0' }
 end


### PR DESCRIPTION
Without this you have to manually specify the Swift version every time you do a pod update or pod install